### PR TITLE
Updated README.md for ubiq repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Ethereum Network Stats
 ============
 [![Build Status][travis-image]][travis-url] [![dependency status][dep-image]][dep-url]
 
-This is a visual interface for tracking ethereum network status. It uses WebSockets to receive stats from running nodes and output them through an angular interface. It is the front-end implementation for [eth-net-intelligence-api](https://github.com/cubedro/eth-net-intelligence-api).
+This is a visual interface for tracking ubiq network status. It uses WebSockets to receive stats from running nodes and output them through an angular interface. It is the front-end implementation for [ubiq-net-intelligence-api](https://github.com/ubiq/ubiq-net-intelligence-api).
 
 ![Screenshot](https://raw.githubusercontent.com/cubedro/eth-netstats/master/src/images/screenshot.jpg?v=0.0.6 "Screenshot")
 
@@ -16,7 +16,7 @@ Make sure you have node.js and npm installed.
 Clone the repository and install the dependencies
 
 ```bash
-git clone https://github.com/cubedro/eth-netstats
+git clone https://github.com/ubiq/eth-netstats
 cd eth-netstats
 npm install
 sudo npm install -g grunt-cli


### PR DESCRIPTION
The README file contains links to the original eth-netstats & eth-net-intelligence-api, which are confusing as they should be pointing to their corresponding forks ubiq/eth-netstats & ubiq-net-intelligence-api for consistency.